### PR TITLE
return option for git remote

### DIFF
--- a/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
@@ -16,13 +16,13 @@
 
 package uk.gov.hmrc
 
-import org.scalatest.{ShouldMatchers, WordSpec}
+import org.scalatest.{OptionValues, ShouldMatchers, WordSpec}
 
-class ArtefactDescriptionSpec extends WordSpec with ShouldMatchers {
+class ArtefactDescriptionSpec extends WordSpec with ShouldMatchers with OptionValues{
 
   "remote url" should {
     "find the remote connection url" in {
-      Git.remoteConnectionUrl shouldBe "git@github.com:hmrc/sbt-auto-build.git"
+      Git.findRemoteConnectionUrl.value shouldBe "git@github.com:hmrc/sbt-auto-build.git"
     }
   }
 


### PR DESCRIPTION
Currently if the user is in the process of setting up a new scala project they must have a git remote configured. This is unreasonable as users should be allowed to use sbt-auto-build before pushing their work to github. This PR fixes the issue by tolerating no git remote. Instead the git remote url will be empty (None).