### PR TITLE
Filter origins with empty urls

### DIFF
--- a/src/main/scala/uk/gov/hmrc/SbtAutoBuildPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/SbtAutoBuildPlugin.scala
@@ -158,8 +158,9 @@ object Git {
   }
 
   lazy val findRemoteConnectionUrl: Option[String] = {
+
     val originUrlOpt = gitConfig.getSubsections("remote")
-      .map(remoteUrl)
+      .flatMap(remoteUrl)
       .headOption
 
     originUrlOpt.map { originUrl =>
@@ -168,8 +169,8 @@ object Git {
     }
   }
 
-  private def remoteUrl(remoteName: String): String = {
-    val remoteUrl = gitConfig.getString("remote", remoteName, "url")
+  private def remoteUrl(remoteName: String): Option[String] = {
+    val remoteUrl = Option(gitConfig.getString("remote", remoteName, "url"))
     logger.info(s"The config section 'remote' with subsection '$remoteName' had a url of '$remoteUrl'")
     remoteUrl
   }

--- a/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ class ArtefactDescriptionSpec extends WordSpec with ShouldMatchers with OptionVa
 
   "remote url" should {
     "find the remote connection url" in {
-      Git.findRemoteConnectionUrl.value should (be("git@github.com:hmrc/sbt-auto-build.git") or be("https://github.com/hmrc/sbt-auto-build.git"))
+      Git.findRemoteConnectionUrl.value should
+        fullyMatch regex("(git@github.com:([^/]*)/sbt-auto-build.git)|(https://github.com/([^/]*)/sbt-auto-build.git)")
     }
   }
 


### PR DESCRIPTION
In certain situations is it possible to have remotes with empty urls. For example, if you want to default upstreams to get PR branches, you may add a global config:
`git config --global --add remote.upstream.fetch "+refs/pull/*/head:refs/remotes/upstream/pr/*"`

This works until you go to a repository that doesn't have an upstream, at which point sbt-auto-build throws an exception, as receives a null for the url. The change is fairly simple to ignore remotes with no url configured

I considered adding an additional test for this case, but it seems that the Git object needs significant restructuring before it can example files injected into it