### PR TITLE
Use Current Remote to find remote url

### DIFF
--- a/project/PluginBuild.scala
+++ b/project/PluginBuild.scala
@@ -50,7 +50,7 @@ object PluginBuild extends Build {
       addSbtPlugin("uk.gov.hmrc" % "sbt-utils" % "2.8.0"),
       libraryDependencies ++= Seq(
         "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.7.0.201502260915-r",
-        "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+        "org.scalatest" %% "scalatest" % "2.2.6" % "test",
         "org.pegdown" % "pegdown" % "1.5.0" % "test"
       )
     )

--- a/src/main/scala/uk/gov/hmrc/SbtAutoBuildPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/SbtAutoBuildPlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package uk.gov.hmrc
 
 import de.heikoseeberger.sbtheader.AutomateHeaderPlugin
-import org.eclipse.jgit.lib.StoredConfig
+import org.eclipse.jgit.lib.{BranchConfig, Repository}
 import sbt.Keys._
 import sbt._
 
@@ -140,28 +140,30 @@ object ArtefactDescription {
   }
 }
 
-object Git {
+object Git extends Git {
+  override lazy val repository: Repository = {
+    import org.eclipse.jgit.storage.file.FileRepositoryBuilder
+    val builder = new FileRepositoryBuilder
+    builder.findGitDir.build
+  }
+}
 
+trait Git {
   val logger = ConsoleLogger()
+  val repository: Repository
 
-  import scala.collection.JavaConversions._
+  def homepage: Option[URL] = browserUrl map url
 
-  def homepage:Option[URL] = browserUrl map url
-
-  def browserUrl:Option[String] = {
+  def browserUrl: Option[String] = {
     findRemoteConnectionUrl map browserUrl
   }
 
-  def browserUrl(remoteConnectionUrl:String):String = {
-    val removedProtocol = removeProtocol(remoteConnectionUrl)
-    s"https://${removedProtocol.toLowerCase.replaceFirst(":", "/")}"
-  }
-
-  lazy val findRemoteConnectionUrl: Option[String] = {
-
-    val originUrlOpt = gitConfig.getSubsections("remote")
-      .flatMap(remoteUrl)
-      .headOption
+  def findRemoteConnectionUrl: Option[String] = {
+    val config = repository.getConfig
+    assert(!repository.getBranch().isEmpty, "No current branch")
+    val branchConfig = new BranchConfig(config, repository.getBranch())
+    // lookup origin for branch
+    val originUrlOpt = Option(config.getString("remote", branchConfig.getRemote, "url"))
 
     originUrlOpt.map { originUrl =>
       val gitTcpRex = "^(git:\\/\\/)".r
@@ -169,20 +171,18 @@ object Git {
     }
   }
 
+  private def browserUrl(remoteConnectionUrl: String): String = {
+    val removedProtocol = removeProtocol(remoteConnectionUrl)
+    s"https://${removedProtocol.toLowerCase.replaceFirst(":", "/")}"
+  }
+
   private def remoteUrl(remoteName: String): Option[String] = {
-    val remoteUrl = Option(gitConfig.getString("remote", remoteName, "url"))
+    val remoteUrl = Option(repository.getConfig.getString("remote", remoteName, "url"))
     logger.info(s"The config section 'remote' with subsection '$remoteName' had a url of '$remoteUrl'")
     remoteUrl
   }
 
   private def removeProtocol(connectionUrl: String): String = {
     "^(git@|git:\\/\\/|.git)".r.replaceFirstIn(connectionUrl, "")
-  }
-
-  private lazy val gitConfig: StoredConfig = {
-    import org.eclipse.jgit.storage.file.FileRepositoryBuilder
-    val builder = new FileRepositoryBuilder
-    val repository = builder.readEnvironment.findGitDir.build
-    repository.getConfig
   }
 }

--- a/src/main/scala/uk/gov/hmrc/SbtAutoBuildPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/SbtAutoBuildPlugin.scala
@@ -158,8 +158,9 @@ object Git {
   }
 
   lazy val findRemoteConnectionUrl: Option[String] = {
+
     val originUrlOpt = gitConfig.getSubsections("remote")
-      .map(remoteUrl)
+      .flatMap(remoteUrl)
       .headOption
 
     originUrlOpt.map { originUrl =>
@@ -168,8 +169,8 @@ object Git {
     }
   }
 
-  private def remoteUrl(remoteName: String): String = {
-    val remoteUrl = gitConfig.getString("remote", remoteName, "url")
+  private def remoteUrl(remoteName: String): Option[String] = {
+    val remoteUrl = Option(gitConfig.getString("remote", remoteName, "url"))
     logger.info(s"The config section 'remote' with subsection '$remoteName' had a url of '$remoteUrl'")
     remoteUrl
   }

--- a/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
@@ -16,34 +16,83 @@
 
 package uk.gov.hmrc
 
-import org.scalatest.{OptionValues, ShouldMatchers, WordSpec}
+import org.scalatest._
 
-class ArtefactDescriptionSpec extends WordSpec with ShouldMatchers with OptionValues{
 
-  "remote url" should {
-    "find the remote connection url" in {
-      Git.findRemoteConnectionUrl.value should
-        fullyMatch regex("(git@github.com:([^/]*)/sbt-auto-build.git)|(https://github.com/([^/]*)/sbt-auto-build.git)")
+class ArtefactDescriptionSpec extends WordSpec with GitRepository with ShouldMatchers with OptionValues {
+
+  "remote url" must {
+    "find the remote connection url for the current branch with a single remote" in {
+      gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:origin/non-existent.git")
+
+      gitHelper.createTestCommit()
+
+      git.findRemoteConnectionUrl.value shouldBe "git@github.com:origin/non-existent.git"
+    }
+
+    "find the remote connection url for the current branch with multiple remotes" in {
+      gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:origin/non-existent.git")
+      gitHelper.setRemoteWithBranch("remote1", "branch1", "git@github.com:remote1/non-existent.git")
+      gitHelper.setRemoteWithBranch("remote2", "branch2", "git@github.com:remote2/non-existent.git")
+
+      gitHelper.createTestCommit()
+
+      git.findRemoteConnectionUrl.value shouldBe "git@github.com:origin/non-existent.git"
+
+      gitHelper.checkoutNewBranch("branch1")
+
+      git.findRemoteConnectionUrl.value shouldBe "git@github.com:remote1/non-existent.git"
+
+      gitHelper.checkoutNewBranch("branch2")
+
+      git.findRemoteConnectionUrl.value shouldBe "git@github.com:remote2/non-existent.git"
+    }
+
+    "find the remote connection url when other branches have no url set" in {
+      gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:origin/non-existent.git")
+
+      // One possible situation this occurs is if there is a remote section in the global config,
+      // for example, to set the refspec or other properties globally, but that remote doesn't exist in the
+      // current repository
+      gitHelper.setRemoteWithBranch("remote1", "branch1", null)
+      gitHelper.setRemoteWithBranch("remote2", "branch2", "git@github.com:remote2/non-existent.git")
+
+      gitHelper.createTestCommit()
+
+      gitHelper.checkoutNewBranch("branch1")
+      git.findRemoteConnectionUrl shouldBe (None)
+
+      gitHelper.checkoutNewBranch("branch2")
+
+      git.findRemoteConnectionUrl.value shouldBe "git@github.com:remote2/non-existent.git"
+    }
+
+    "transform remote connection url with git:// to git@" in {
+      gitHelper.setRemoteWithBranch("origin", "master", "git://github.com:hmrc/sbt-auto-build1.git")
+      git.findRemoteConnectionUrl.value shouldBe "git@github.com:hmrc/sbt-auto-build1.git"
     }
   }
 
   "create the browser url" should {
-
     "be created when connection url starting with 'git@'" in {
-      Git.browserUrl("git@github.com:hmrc/sbt-auto-build") shouldBe "https://github.com/hmrc/sbt-auto-build"
+      gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:hmrc/sbt-auto-build")
+      git.browserUrl.value shouldBe "https://github.com/hmrc/sbt-auto-build"
     }
 
     "be created when connection url starting with 'git@' on a fork" in {
-      Git.browserUrl("git@github.com:user/sbt-auto-build") shouldBe "https://github.com/user/sbt-auto-build"
+      gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:hmrc-collaborator/sbt-auto-build")
+      git.browserUrl.value shouldBe "https://github.com/hmrc-collaborator/sbt-auto-build"
     }
 
     "be created when connection url starting with 'git://'" in {
-      Git.browserUrl("git://github.com:hmrc/sbt-auto-build") shouldBe "https://github.com/hmrc/sbt-auto-build"
+      gitHelper.setRemoteWithBranch("origin", "master", "git://github.com:hmrc/sbt-auto-build")
+      git.browserUrl.value shouldBe "https://github.com/hmrc/sbt-auto-build"
     }
 
     "be created when connection url has repo organisation in capitals" in {
-      Git.browserUrl("git://github.com:HMRC/sbt-auto-build") shouldBe "https://github.com/hmrc/sbt-auto-build"
-      Git.browserUrl("git://github.com:hmrc/sbt-auto-build") shouldBe "https://github.com/hmrc/sbt-auto-build"
+      gitHelper.setRemoteWithBranch("origin", "master", "git://github.com:HMRC/sbt-auto-build")
+      git.browserUrl.value shouldBe "https://github.com/hmrc/sbt-auto-build"
     }
   }
 }
+

--- a/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ class ArtefactDescriptionSpec extends WordSpec with ShouldMatchers with OptionVa
 
   "remote url" should {
     "find the remote connection url" in {
-      Git.findRemoteConnectionUrl.value should (be("git@github.com:hmrc/sbt-auto-build.git") or be("https://github.com/hmrc/sbt-auto-build.git"))
+      Git.findRemoteConnectionUrl.value should
+        fullyMatch regex("(git@github.com:([^/]*)/sbt-auto-build.git)|(https://github.com/([^/]*)/sbt-auto-build.git)")
     }
   }
 

--- a/src/test/scala/uk/gov/hmrc/GitRepository.scala
+++ b/src/test/scala/uk/gov/hmrc/GitRepository.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc
+
+import java.nio.file.Path
+
+import org.scalatest.{Suite, BeforeAndAfterEach}
+
+import scala.reflect.io.File
+
+trait GitRepository extends BeforeAndAfterEach { this: Suite =>
+
+  // The use of var looks like a concurrency issue, but ScalaTest will actually create a new instance of the Suite
+  // per Test, and is the recommended practice. See fixtures section in http://doc.scalatest.org/2.2.6/index.html#org.scalatest.FlatSpec
+  var tempWorkDir: Path = _
+  var gitHelper: GitHelper = _
+
+  // GitInfo, whilst could be declared in each test, is in the fixture, as it should be cleaned up after each test by calling close()
+  var git: Git = _
+
+  override def beforeEach() = {
+    tempWorkDir = java.nio.file.Files.createTempDirectory("git_test")
+    gitHelper = new GitHelper(tempWorkDir)
+    git = new Git {
+      override val repository = {
+        gitHelper.repo
+      }
+    }
+    super.beforeEach() // To be stackable, must call super.beforeEach
+  }
+
+  override def afterEach() = {
+    try {
+      super.afterEach() // To be stackable, must call super.afterEach
+    }
+    finally {
+      gitHelper.close()
+      assert(new File(tempWorkDir.toFile).deleteRecursively(), "failed to delete file")
+    }
+  }
+}
+
+import java.nio.file.Path
+
+class GitHelper(tempWorkDir: Path) {
+
+  val jgit = org.eclipse.jgit.api.Git.init().setDirectory(tempWorkDir.toFile).call()
+  val repo = jgit.getRepository
+
+  val currentBranch = repo.getFullBranch
+  val gitConfig = repo.getConfig
+
+  def setRemote(name: String, url: String) = {
+    gitConfig.setString("remote", name, "url", url)
+    gitConfig.setString("remote", name, "fetch", s"+refs/heads/*:refs/remotes/$name/*")
+  }
+
+  def setBranch(name: String, remote: String) = {
+    gitConfig.setString("branch", name, "remote", remote)
+    gitConfig.setString("branch", name, "merge", s"refs/heads/$name")
+  }
+
+  def setRemoteWithBranch(remote: String, branch: String, url: String) = {
+    setRemote(remote, url)
+    setBranch(branch, remote)
+  }
+
+  def checkoutNewBranch(name: String) = {
+    val checkout = jgit.checkout()
+    checkout.setName(name)
+    checkout.setCreateBranch(true)
+    checkout.call()
+  }
+
+  def createTestCommit() = {
+    val commit = jgit.commit()
+    commit.setMessage("test commit")
+    commit.call()
+  }
+
+  def close() = jgit.close()
+}


### PR DESCRIPTION
@beyond-code-github see what you think about this change to add more comprehensive test coverage to old and new changes. It will obsolete https://github.com/hmrc/sbt-auto-build/pull/6 if you agree with the changes.

In summary here are the changes:

- Previously the Git helper selected the first remote defined in the project, which may or may not be the remote
- It works in may cases, but not all.
- This change also includes tolerance to URLs not provided in remotes that are not being used, or have been defined
- in global scope.
- The test coverage did not pick up these cases before, and was limited because it only used the local git setup for
- this repo. This did not allow test coverage of corner cases, and also meant that the API exposed private methods.
- A git test trait has been added which allows flexibility to create one git repo per test with a custom configuration.
- In addition, the use of matcher syntax has been unified
- Scalatest version bump

I have tested it manually as a plugin in another project too.