### PR TITLE
Add default to origin and fix browser url

### DIFF
--- a/src/main/scala/uk/gov/hmrc/SbtAutoBuildPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/SbtAutoBuildPlugin.scala
@@ -181,10 +181,12 @@ trait Git {
 
   private def browserUrl(remoteConnectionUrl: String): String = {
     val removedProtocol = removeProtocol(remoteConnectionUrl)
-    s"https://${removedProtocol.toLowerCase.replaceFirst(":", "/")}"
+    val replacedSeparator = removedProtocol.toLowerCase.replaceFirst(":", "/")
+    val removedGitSuffix = replacedSeparator.replaceFirst(".git$", "")
+    s"https://$removedGitSuffix"
   }
 
   private def removeProtocol(connectionUrl: String): String = {
-    "^(git@|git:\\/\\/|.git)".r.replaceFirstIn(connectionUrl, "")
+    "^(git@|git://|https://)".r.replaceFirstIn(connectionUrl, "")
   }
 }

--- a/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
@@ -58,6 +58,16 @@ class ArtefactDescriptionSpec extends WordSpec with GitRepository with ShouldMat
       git.findRemoteConnectionUrl.value shouldBe "git@github.com:origin/non-existent.git"
     }
 
+    "find the remote connection url defaulted to the origin remote when master does not exist" in {
+      gitHelper.setRemote("origin","git@github.com:origin/non-existent.git")
+
+      val rev = gitHelper.createTestCommit()
+
+      gitHelper.checkoutBranch(rev)
+
+      git.findRemoteConnectionUrl.value shouldBe "git@github.com:origin/non-existent.git"
+    }
+
     "find the remote connection url when other branches have no url set" in {
       gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:origin/non-existent.git")
 

--- a/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
@@ -95,22 +95,27 @@ class ArtefactDescriptionSpec extends WordSpec with GitRepository with ShouldMat
 
   "create the browser url" should {
     "be created when connection url starting with 'git@'" in {
-      gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:hmrc/sbt-auto-build")
+      gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:hmrc/sbt-auto-build.git")
       git.browserUrl.value shouldBe "https://github.com/hmrc/sbt-auto-build"
     }
 
     "be created when connection url starting with 'git@' on a fork" in {
-      gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:hmrc-collaborator/sbt-auto-build")
+      gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:hmrc-collaborator/sbt-auto-build.git")
       git.browserUrl.value shouldBe "https://github.com/hmrc-collaborator/sbt-auto-build"
     }
 
+    "be created when connection url starting with 'https://" in {
+      gitHelper.setRemoteWithBranch("origin", "master", "https://github.com/hmrc/sbt-auto-build.git")
+      git.browserUrl.value shouldBe "https://github.com/hmrc/sbt-auto-build"
+    }
+
     "be created when connection url starting with 'git://'" in {
-      gitHelper.setRemoteWithBranch("origin", "master", "git://github.com:hmrc/sbt-auto-build")
+      gitHelper.setRemoteWithBranch("origin", "master", "git://github.com:hmrc/sbt-auto-build.git")
       git.browserUrl.value shouldBe "https://github.com/hmrc/sbt-auto-build"
     }
 
     "be created when connection url has repo organisation in capitals" in {
-      gitHelper.setRemoteWithBranch("origin", "master", "git://github.com:HMRC/sbt-auto-build")
+      gitHelper.setRemoteWithBranch("origin", "master", "git://github.com:HMRC/sbt-auto-build.git")
       git.browserUrl.value shouldBe "https://github.com/hmrc/sbt-auto-build"
     }
   }


### PR DESCRIPTION
- Correct the browserUrl functionality to deal with git being cloned over HTTPS
- Remove incorrect git suffix from browserUrl. e.g. http://github.com/hmrc/sbt-auto-build.git is not actually the correct homepage. It should be http://github.com/hmrc/sbt-auto-build
- When determining the remote URL, fall back to origin if it can't be resolved from the current branch or master