### PR TITLE
AutoBuild require sbt-artifactory and sbt-git-versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 scala:
 - 2.10.5
 jdk:
-- oraclejdk7
+- oraclejdk8
 cache:
   directories:
     - '$HOME/.ivy2/cache'

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,8 @@ lazy val project = Project(pluginName, file("."))
     addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.1.1"),
     addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.8.0"),
     addSbtPlugin("uk.gov.hmrc" % "sbt-settings" % "3.8.0"),
+    addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.17.0"),
+    addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0"),
     libraryDependencies ++= Seq(
       "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.7.0.201502260915-r",
       "org.scalatest" %% "scalatest" % "2.2.6" % "test",

--- a/src/main/scala/uk/gov/hmrc/SbtAutoBuildPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/SbtAutoBuildPlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/SbtAutoBuildPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/SbtAutoBuildPlugin.scala
@@ -21,6 +21,7 @@ import org.eclipse.jgit.lib.{BranchConfig, Repository, StoredConfig}
 import play.twirl.sbt.Import.TwirlKeys
 import sbt.Keys._
 import sbt._
+import uk.gov.hmrc.versioning.SbtGitVersioning
 
 import scala.util.matching.Regex
 
@@ -43,7 +44,7 @@ object SbtAutoBuildPlugin extends AutoPlugin {
       ArtefactDescription() ++
       Seq(autoSourceHeader := true, forceSourceHeader := false)
 
-  override def requires: Plugins = AutomateHeaderPlugin
+  override def requires: Plugins = AutomateHeaderPlugin && SbtArtifactory && SbtGitVersioning
 
   override def trigger: PluginTrigger = noTrigger
 

--- a/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/GitRepository.scala
+++ b/src/test/scala/uk/gov/hmrc/GitRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This change allow to use only `sbt-auto-build` plugin into platform builds.