### PR TITLE
BDOG-516 remove dependency on sbt-twirl plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,9 +22,6 @@ lazy val project = Project(pluginName, file("."))
     scalaVersion := "2.10.7",
     crossSbtVersions := Vector("0.13.18", "1.3.4"),
     targetJvm := "jvm-1.8",
-    // Kept at 1.4.2, the last release that is cross-compiled for 2.11
-    // See comment on https://jira.tools.tax.service.gov.uk/browse/BDOG-516
-    addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.4.2"),
     addSbtPlugin("de.heikoseeberger" % "sbt-header" % "3.0.2"),
     addSbtPlugin("uk.gov.hmrc" % "sbt-settings" % "4.0.0"),
     libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,8 +4,6 @@ resolvers ++= Seq(
 
 resolvers += Resolver.bintrayRepo("hmrc", "releases")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.4.2")
-
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "3.0.2")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")

--- a/src/main/scala/uk/gov/hmrc/SbtAutoBuildPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/SbtAutoBuildPlugin.scala
@@ -21,7 +21,6 @@ import java.time.LocalDate
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import de.heikoseeberger.sbtheader.{AutomateHeaderPlugin, CommentStyle, FileType}
 import org.eclipse.jgit.lib.{BranchConfig, Repository, StoredConfig}
-import play.twirl.sbt.Import.TwirlKeys
 import sbt.Keys._
 import sbt.{Setting, _}
 
@@ -49,11 +48,17 @@ object SbtAutoBuildPlugin extends AutoPlugin {
 
   override lazy val projectSettings: Seq[Setting[_]] = {
 
+    // Taken from the sbt-twirl plugin to avoid declaring a full dependency (which this plugin used previously)
+    // That caused potential evictions of the `twirl-api` library and inconsistencies depending on the version used by clients
+    // See comment on https://jira.tools.tax.service.gov.uk/browse/BDOG-516
+    val twirlCompileTemplates =
+      TaskKey[Seq[File]]("twirl-compile-templates", "Compile twirl templates into scala source files")
+
     val addedSettings = Seq(
       // targetJvm declared here means that anyone using the plugin will inherit this by default. It only needs to
       // be specified by clients if they want to override it
       targetJvm := "jvm-1.8",
-      unmanagedSources.in(Compile, headerCreate) ++= sources.in(Compile, TwirlKeys.compileTemplates).value
+      unmanagedSources.in(Compile, headerCreate) ++= sources.in(Compile, twirlCompileTemplates).value
     ) ++ defaultAutoSettings ++ HeaderSettings(autoSourceHeader, forceSourceHeader)
 
     logger.info(s"SbtAutoBuildPlugin - adding ${addedSettings.size} build settings")


### PR DESCRIPTION
1. Removes the dependency which was pulled in and ending up on the classpath for all clients, merely to be able to use a simple TaskKey. Otherwise, if a client brings in e.g. `addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")` then the version of `twirl-api` that gets resolved might be evicted in favour of one from `sbt-auto-build`, which was causing peculiarities and binary incompatibilities. 