### PR TITLE
BDOG-1444 Remove references to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In order to apply the correct licence or copyright headers to the start of all o
 
  1. Your repository contains a `repository.yaml` file at the root of the project, with a valid `repoVisibility` identifier.
  See [here](https://confluence.tools.tax.service.gov.uk/x/k_8TCQ) for more info
- 1. If your repository is marked as being *public*: A `LICENSE` file _must_ exist, and must be the Apache V2.0 licence, like [this one](https://github.com/hmrc/service-dependencies/blob/master/LICENSE)
+ 1. If your repository is marked as being *public*: A `LICENSE` file _must_ exist, and must be the Apache V2.0 licence, like [this one](https://github.com/hmrc/service-dependencies/blob/HEAD/LICENSE)
  1. If your repository is marked as being *private*: A `LICENSE` file _must not_ exist
 
 > Note the spelling of the LICENSE file with an `S` not a `C`

--- a/src/main/scala/uk/gov/hmrc/ArtefactDescription.scala
+++ b/src/main/scala/uk/gov/hmrc/ArtefactDescription.scala
@@ -18,6 +18,8 @@ package uk.gov.hmrc
 
 import sbt.Keys.{developers, homepage, organizationHomepage, pomPostProcess, scmInfo}
 import sbt.{ScmInfo, url}
+import scala.xml.transform.{RewriteRule, RuleTransformer}
+import scala.xml._
 
 object ArtefactDescription {
 
@@ -28,13 +30,9 @@ object ArtefactDescription {
 
     // workaround for sbt/sbt#1834
     pomPostProcess := {
-
-      import scala.xml.transform.{RewriteRule, RuleTransformer}
-      import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
-
-      node: XmlNode =>
+      node: Node =>
         new RuleTransformer(new RewriteRule {
-          override def transform(node: XmlNode): XmlNodeSeq = node match {
+          override def transform(node: Node): NodeSeq = node match {
             case e: Elem if e.label == "developers" =>
               <developers>
                 {developers.value.map { dev =>
@@ -52,9 +50,8 @@ object ArtefactDescription {
     }
   )
 
-  def buildScmInfo: Option[ScmInfo] = {
-    for (connUrl <- GitUtils.findRemoteConnectionUrl;
-         browserUrl <- GitUtils.browserUrl)
-      yield ScmInfo(url(browserUrl), connUrl)
-  }
+  def buildScmInfo: Option[ScmInfo] = for {
+      connUrl <- GitUtils.findRemoteConnectionUrl;
+      browserUrl <- GitUtils.browserUrl
+    } yield ScmInfo(url(browserUrl), connUrl)
 }

--- a/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ArtefactDescriptionSpec.scala
@@ -23,54 +23,44 @@ import org.scalatest.wordspec.AnyWordSpec
 class ArtefactDescriptionSpec extends AnyWordSpec with GitRepository with Matchers with OptionValues {
 
   "remote url" must {
-    "find the remote connection url for the current branch with a single remote" in {
-      gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:origin/non-existent.git")
+    "find the remote connection url for origin" in {
+      gitHelper.setRemote("origin", "git@github.com:origin/non-existent.git")
 
       gitHelper.createTestCommit()
 
-      git.findRemoteConnectionUrl.value shouldBe "git@github.com:origin/non-existent.git"
+      git.findRemoteConnectionUrl().value shouldBe "git@github.com:origin/non-existent.git"
     }
 
-    "find the remote connection url for the current branch with multiple remotes" in {
-      gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:origin/non-existent.git")
+    "find the remote connection url for origin when multiple remotes set" in {
+      gitHelper.setRemoteWithBranch("origin", "main", "git@github.com:origin/non-existent.git")
       gitHelper.setRemoteWithBranch("remote1", "branch1", "git@github.com:remote1/non-existent.git")
       gitHelper.setRemoteWithBranch("remote2", "branch2", "git@github.com:remote2/non-existent.git")
 
       gitHelper.createTestCommit()
 
-      git.findRemoteConnectionUrl.value shouldBe "git@github.com:origin/non-existent.git"
+      git.findRemoteConnectionUrl().value shouldBe "git@github.com:origin/non-existent.git"
 
       gitHelper.checkoutNewBranch("branch1")
 
-      git.findRemoteConnectionUrl.value shouldBe "git@github.com:remote1/non-existent.git"
+      git.findRemoteConnectionUrl().value shouldBe "git@github.com:origin/non-existent.git"
 
       gitHelper.checkoutNewBranch("branch2")
 
-      git.findRemoteConnectionUrl.value shouldBe "git@github.com:remote2/non-existent.git"
+      git.findRemoteConnectionUrl().value shouldBe "git@github.com:origin/non-existent.git"
     }
 
-    "find the remote connection url defaulted to the remote for master when in a branch without tracking info" in {
-      gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:origin/non-existent.git")
-
-      val rev = gitHelper.createTestCommit()
-
-      gitHelper.checkoutBranch(rev)
-
-      git.findRemoteConnectionUrl.value shouldBe "git@github.com:origin/non-existent.git"
-    }
-
-    "find the remote connection url defaulted to the origin remote when master does not exist" in {
+    "find the remote connection url defaulted to the origin remote when main branch does not exist" in {
       gitHelper.setRemote("origin","git@github.com:origin/non-existent.git")
 
       val rev = gitHelper.createTestCommit()
 
       gitHelper.checkoutBranch(rev)
 
-      git.findRemoteConnectionUrl.value shouldBe "git@github.com:origin/non-existent.git"
+      git.findRemoteConnectionUrl().value shouldBe "git@github.com:origin/non-existent.git"
     }
 
     "find the remote connection url when other branches have no url set" in {
-      gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:origin/non-existent.git")
+      gitHelper.setRemoteWithBranch("origin", "main", "git@github.com:origin/non-existent.git")
 
       // One possible situation this occurs is if there is a remote section in the global config,
       // for example, to set the refspec or other properties globally, but that remote doesn't exist in the
@@ -81,43 +71,51 @@ class ArtefactDescriptionSpec extends AnyWordSpec with GitRepository with Matche
       gitHelper.createTestCommit()
 
       gitHelper.checkoutNewBranch("branch1")
-      git.findRemoteConnectionUrl.value shouldBe "git@github.com:origin/non-existent.git"
+      git.findRemoteConnectionUrl().value shouldBe "git@github.com:origin/non-existent.git"
 
       gitHelper.checkoutNewBranch("branch2")
 
-      git.findRemoteConnectionUrl.value shouldBe "git@github.com:remote2/non-existent.git"
+      git.findRemoteConnectionUrl().value shouldBe "git@github.com:origin/non-existent.git"
+    }
+
+    "return None when origin is not set" in {
+      git.findRemoteConnectionUrl() shouldBe None
+
+      gitHelper.setRemoteWithBranch("upstream", "main", "git@github.com:origin/non-existent.git")
+
+      git.findRemoteConnectionUrl() shouldBe None
     }
 
     "transform remote connection url with git:// to git@" in {
-      gitHelper.setRemoteWithBranch("origin", "master", "git://github.com:hmrc/sbt-auto-build1.git")
-      git.findRemoteConnectionUrl.value shouldBe "git@github.com:hmrc/sbt-auto-build1.git"
+      gitHelper.setRemoteWithBranch("origin", "main", "git://github.com:hmrc/sbt-auto-build1.git")
+      git.findRemoteConnectionUrl().value shouldBe "git@github.com:hmrc/sbt-auto-build1.git"
     }
   }
 
   "create the browser url" should {
     "be created when connection url starting with 'git@'" in {
-      gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:hmrc/sbt-auto-build.git")
-      git.browserUrl.value shouldBe "https://github.com/hmrc/sbt-auto-build"
+      gitHelper.setRemoteWithBranch("origin", "main", "git@github.com:hmrc/sbt-auto-build.git")
+      git.browserUrl().value shouldBe "https://github.com/hmrc/sbt-auto-build"
     }
 
     "be created when connection url starting with 'git@' on a fork" in {
-      gitHelper.setRemoteWithBranch("origin", "master", "git@github.com:hmrc-collaborator/sbt-auto-build.git")
-      git.browserUrl.value shouldBe "https://github.com/hmrc-collaborator/sbt-auto-build"
+      gitHelper.setRemoteWithBranch("origin", "main", "git@github.com:hmrc-collaborator/sbt-auto-build.git")
+      git.browserUrl().value shouldBe "https://github.com/hmrc-collaborator/sbt-auto-build"
     }
 
     "be created when connection url starting with 'https://" in {
-      gitHelper.setRemoteWithBranch("origin", "master", "https://github.com/hmrc/sbt-auto-build.git")
-      git.browserUrl.value shouldBe "https://github.com/hmrc/sbt-auto-build"
+      gitHelper.setRemoteWithBranch("origin", "main", "https://github.com/hmrc/sbt-auto-build.git")
+      git.browserUrl().value shouldBe "https://github.com/hmrc/sbt-auto-build"
     }
 
     "be created when connection url starting with 'git://'" in {
-      gitHelper.setRemoteWithBranch("origin", "master", "git://github.com:hmrc/sbt-auto-build.git")
-      git.browserUrl.value shouldBe "https://github.com/hmrc/sbt-auto-build"
+      gitHelper.setRemoteWithBranch("origin", "main", "git://github.com:hmrc/sbt-auto-build.git")
+      git.browserUrl().value shouldBe "https://github.com/hmrc/sbt-auto-build"
     }
 
     "be created when connection url has repo organisation in capitals" in {
-      gitHelper.setRemoteWithBranch("origin", "master", "git://github.com:HMRC/sbt-auto-build.git")
-      git.browserUrl.value shouldBe "https://github.com/hmrc/sbt-auto-build"
+      gitHelper.setRemoteWithBranch("origin", "main", "git://github.com:HMRC/sbt-auto-build.git")
+      git.browserUrl().value shouldBe "https://github.com/hmrc/sbt-auto-build"
     }
   }
 }


### PR DESCRIPTION
```
[core]
	repositoryformatversion = 0
	filemode = true
	logallrefupdates = true
	precomposeunicode = true
[remote "origin"]
	url = git@github.com:chotai/non-existent.git
	fetch = +refs/heads/*:refs/remotes/origin/*
[remote "upstream"]
	url = git@github.com:hmrc/non-existent.git
	fetch = +refs/heads/*:refs/remotes/upstream/*
[remote "fork-origin"]
	url = git@github.com:fork-origin/non-existent.git
	fetch = +refs/heads/*:refs/remotes/fork-origin/*
[branch "master"]
	remote = origin
	merge = refs/heads/master
[branch "BDOG-1234"]
	remote = origin
	merge = refs/heads/BDOG-1234
[branch "BDOG-BAU"]
	remote = upstream
	merge = refs/heads/BDOG-BAU
[branch "BDOG-1000"]
	remote = fork-origin
	merge = refs/heads/BDOG-1000
```
sbt-auto-build looks at git config to work out the urls to set in the scm info (on Maven builds). The logic currently is:
- use the current branch to find the remote name then use that to find the url
- failing that use master to find the remote name and use that to find the remote url (the above should really never fail)
- look for the url in the `origin` remote


When a github repo is cloned, git adds origin by default. It's the url where the repo was cloned from. In the case of a fork, this will be the url where the repo was cloned from (not the original place that was forked).

With the above example, you will get different scm urls depending on what BDOG branch you've checked out - which I don't think is right. The code is trying to cater for multiple remote urls (something that wouldn't happen in Jenkins) and I can't think why you would want the scm information to be anything other than the actual remote url.

The proposal is to stop attempting to find the remote name from branch information and just use `origin`