### PR TITLE
removing line break when calculating md5 hash

### DIFF
--- a/src/main/scala/uk/gov/hmrc/HeaderUtils.scala
+++ b/src/main/scala/uk/gov/hmrc/HeaderUtils.scala
@@ -30,14 +30,15 @@ object HeaderUtils {
   // Standard Apache v2 LICENSE (same as the one in this repo), after being trimmed of leading and trailing whitespace.
   // The reason for that is the official Apache licence has a beginning blank line, whereas the copy in most hmrc repo's
   // does not have that.
-  val licenceFileExpectedMD5 = "cc1a9e33dd7a6eb0b79927742cf005c"
-  val licenceFileExpectedMD5_2 = "6c4db32a2fa8717faffa1d4f10136f47" //Older variant with {} replaced by []
+
+  val licenceFileExpectedMD5_2 = "b3893345f6b2cf9623fc3894ea83378b" //Older variant with {} replaced by []
+  val licenceFileExpectedMD5 = "721d5e495a063f455823352ea23420cd"
 
   def md5HashString(s: String): String = {
     import java.math.BigInteger
     import java.security.MessageDigest
     val md = MessageDigest.getInstance("MD5")
-    val digest = md.digest(s.getBytes)
+    val digest = md.digest(s.replaceAll("\n", "").replaceAll("\r", "").getBytes)
     val bigInt = new BigInteger(1,digest)
     val hashedString = bigInt.toString(16)
     hashedString
@@ -52,8 +53,11 @@ object HeaderUtils {
         FileUtils.readFileAsString(licenceFile).toEither.left.map(_ => s"Problem reading LICENSE file")
           // .right projection required to remain backwards compatible with scala 2.10 cross build (for sbt 0.13)
           .right.flatMap(c =>
-          if (Seq(licenceFileExpectedMD5, licenceFileExpectedMD5_2).contains(md5HashString(c.trim))) Right(())
-          else Left(s"The LICENSE file does not contain the appropriate Apache V2 licence. It should match https://www.apache.org/licenses/LICENSE-2.0.txt")
+          Either.cond(
+            Seq(licenceFileExpectedMD5, licenceFileExpectedMD5_2).contains(md5HashString(c.trim)),
+            right = (),
+            left = s"The LICENSE file does not contain the appropriate Apache V2 licence. It should match https://www.apache.org/licenses/LICENSE-2.0.txt"
+          )
         )
       }
       else Left(s"No LICENSE file exists but the repository is marked as public")

--- a/src/test/scala/uk/gov/hmrc/HeaderUtilsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/HeaderUtilsSpec.scala
@@ -29,13 +29,13 @@ class HeaderUtilsSpec extends AnyWordSpec with Matchers {
       val f = new File(getClass.getResource("/LICENSE_APACHE_V2_OLD").getPath)
       val content = FileUtils.readFileAsString(f)
 
-      HeaderUtils.md5HashString(content.success.value.trim) shouldBe "6c4db32a2fa8717faffa1d4f10136f47"
+      HeaderUtils.md5HashString(content.success.value.trim) shouldBe "b3893345f6b2cf9623fc3894ea83378b"
     }
     "return the correct MD5 hash of the licence file (current)" in {
       val f = new File(getClass.getResource("/LICENSE_APACHE_V2_CURRENT").getPath)
       val content = FileUtils.readFileAsString(f)
 
-      HeaderUtils.md5HashString(content.success.value.trim) shouldBe "cc1a9e33dd7a6eb0b79927742cf005c"
+      HeaderUtils.md5HashString(content.success.value.trim) shouldBe "721d5e495a063f455823352ea23420cd"
     }
   }
 


### PR DESCRIPTION
resolves #44 

# Context
branch -> branch PR, alternative is: 

Simply removes the line breaks when calculating the hashes: https://superuser.com/questions/374028/how-are-n-and-r-handled-differently-on-linux-and-windows