### PR TITLE
Update sbt-git-versioning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val project = Project("sbt-auto-build", file("."))
     addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.10.0"),
     addSbtPlugin("uk.gov.hmrc"       % "sbt-setting-keys"   % "0.5.0"),
     addSbtPlugin("uk.gov.hmrc"       % "sbt-settings"       % "4.21.0"),
-    addSbtPlugin("uk.gov.hmrc"       % "sbt-git-versioning" % "2.5.0"),
+    addSbtPlugin("uk.gov.hmrc"       % "sbt-git-versioning" % "2.6.0"),
     libraryDependencies ++= Seq(
       "org.yaml"              %  "snakeyaml"            % "1.25",
       "org.eclipse.jgit"      %  "org.eclipse.jgit"     % "4.11.9.201909030838-r",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 addSbtPlugin("de.heikoseeberger" % "sbt-header"         % "5.10.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-settings"       % "4.21.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-setting-keys"   % "0.5.0")
-addSbtPlugin("uk.gov.hmrc"       % "sbt-git-versioning" % "2.5.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-git-versioning" % "2.6.0")


### PR DESCRIPTION
This drops an old and unnecessary version of `cats-core` on the dependency graph, which was causing conflicts with `sbt-uglify`.